### PR TITLE
feat: add reference page for `atoms`

### DIFF
--- a/components/components/classnamesTable.tsx
+++ b/components/components/classnamesTable.tsx
@@ -1,4 +1,5 @@
 import { googleCalendarAtomClassnamesPropData, availabilitySettingsAtomClassnamesPropData, bookerAtomPropsClassnamesPropData } from "@utils/atomsClassnameTableData";
+import { Atoms } from "@utils/atomsPropTableData";
 
 export default ({
     atom
@@ -7,18 +8,15 @@ export default ({
   }) => {
   let tableData = [{name: '', description: ''}];
 
-  console.log(atom, 'classnames table test');
-  
-
-  if (atom === "google calendar") { 
+  if (atom === Atoms.Gcal) { 
     tableData = googleCalendarAtomClassnamesPropData
   }
 
-  if (atom === "availability settings") {
+  if (atom === Atoms.Availability) {
     tableData = availabilitySettingsAtomClassnamesPropData
   }
 
-  if (atom === 'booker') {
+  if (atom === Atoms.Booker) {
     tableData = bookerAtomPropsClassnamesPropData
   }
 

--- a/components/components/classnamesTable.tsx
+++ b/components/components/classnamesTable.tsx
@@ -1,0 +1,53 @@
+import { googleCalendarAtomClassnamesPropData, availabilitySettingsAtomClassnamesPropData, bookerAtomPropsClassnamesPropData } from "@utils/atomsClassnameTableData";
+
+export default ({
+    atom
+  }: {
+    atom: string;
+  }) => {
+  let tableData = [{name: '', description: ''}];
+
+  console.log(atom, 'classnames table test');
+  
+
+  if (atom === "google calendar") { 
+    tableData = googleCalendarAtomClassnamesPropData
+  }
+
+  if (atom === "availability settings") {
+    tableData = availabilitySettingsAtomClassnamesPropData
+  }
+
+  if (atom === 'booker') {
+    tableData = bookerAtomPropsClassnamesPropData
+  }
+
+  if(atom === "") {
+    return <></>
+  }
+
+    return (
+      <
+      >
+        <table className="mt-8">
+          <tbody>
+            <tr className="border-[0.5px] border-black font-semibold">
+                <td className="border-[0.5px] py-1 px-2 border-black">Classname</td>
+                <td className="border-[0.5px] py-1 px-2 border-black">Description</td>
+            </tr>
+            {
+              tableData.map((prop) => {
+                return (
+                  <tr key={prop.name} className="border-[0.5px] border-black">
+                    <td className="border-[0.5px] py-1 px-2 border-black font-semibold">{prop.name}</td>
+                    <td className="border-[0.5px] py-1 px-2 border-black">{prop.description}</td>
+                  </tr>
+                )
+              })
+            }
+          </tbody>
+        </table>
+      </>
+    );
+  };
+  

--- a/components/components/table.tsx
+++ b/components/components/table.tsx
@@ -1,4 +1,5 @@
 import { bookerAtomPropsData, availabilitySettingsAtomPropsData, googleCalendarAtomPropsData } from "@utils/atomsPropTableData";
+import { Atoms } from "@utils/atomsPropTableData";
 
 export default ({
     atom
@@ -7,15 +8,15 @@ export default ({
   }) => {
   let tableData = [{name: '', required: false, description: ''}];
 
-  if (atom === "google calendar") { 
+  if (atom === Atoms.Gcal) { 
     tableData = googleCalendarAtomPropsData
   }
 
-  if (atom === "availability settings") {
+  if (atom === Atoms.Availability) {
     tableData = availabilitySettingsAtomPropsData
   }
 
-  if (atom === 'booker') {
+  if (atom === Atoms.Booker) {
     tableData = bookerAtomPropsData
   }
 

--- a/components/components/table.tsx
+++ b/components/components/table.tsx
@@ -1,0 +1,52 @@
+import { bookerAtomPropsData, availabilitySettingsAtomPropsData, googleCalendarAtomPropsData } from "@utils/atomsPropTableData";
+
+export default ({
+    atom
+  }: {
+    atom: string;
+  }) => {
+  let tableData = [{name: '', required: false, description: ''}];
+
+  if (atom === "google calendar") { 
+    tableData = googleCalendarAtomPropsData
+  }
+
+  if (atom === "availability settings") {
+    tableData = availabilitySettingsAtomPropsData
+  }
+
+  if (atom === 'booker') {
+    tableData = bookerAtomPropsData
+  }
+
+  if(atom === "") {
+    return <></>
+  }
+
+    return (
+      <
+      >
+        <table className="mt-8">
+          <tbody>
+            <tr className="border-[0.5px] border-black font-semibold">
+                <td className="border-[0.5px] py-1 px-2 border-black">Paramater</td>
+                <td className="border-[0.5px] py-1 px-2 border-black">Required</td>
+                <td className="border-[0.5px] py-1 px-2 border-black">Description</td>
+            </tr>
+            {
+              tableData.map((prop) => {
+                return (
+                  <tr key={prop.name} className="border-[0.5px] border-black">
+                    <td className="border-[0.5px] py-1 px-2 border-black font-semibold">{prop.name}</td>
+                    <td className="border-[0.5px] py-1 px-2 border-black">{prop.required ? 'Yes': 'No'}</td>
+                    <td className="border-[0.5px] py-1 px-2 border-black">{prop.description}</td>
+                  </tr>
+                )
+              })
+            }
+          </tbody>
+        </table>
+      </>
+    );
+  };
+  

--- a/markdoc.components.js
+++ b/markdoc.components.js
@@ -28,6 +28,8 @@ import { Video } from '@components/uicomp/video'
 import { WrappedImage } from '@components/uicomp/wrappedimage'
 import YouTube from '@components/components/youtube'
 import Loom from '@components/components/loom'
+import Table from '@components/components/table'
+import ClassnamesTable from '@components/components/classnamesTable'
 
 export default {
   BorderedPanel,
@@ -59,4 +61,6 @@ export default {
   Video,
   WrappedImage,
   YouTube,
+  Table,
+  ClassnamesTable
 }

--- a/markdoc.config.js
+++ b/markdoc.config.js
@@ -288,6 +288,14 @@ const config = {
       render: 'YouTube',
       attributes: { src: { type: String } },
     },
+    table: {
+      render: 'Table',
+      attributes: { atom: { type: String } },
+    },
+    classnamesTable : {
+      render: 'ClassnamesTable',
+      attributes: { atom: { type: String } },
+    }
   },
   nodes: {
     fence: {

--- a/pages/platform/atoms-reference/index.mdoc
+++ b/pages/platform/atoms-reference/index.mdoc
@@ -29,11 +29,13 @@ Below is a list of tables that contains all the available classnames that can be
 
 ### 2. Availability settings atom
 
+Availability settings atom accepts custom styles via the **customClassNames** prop. All the props that we see below fall under this **customClassNames** prop.
+
 {% classnamesTable atom="availability settings" /%}
 
 ### 3. Booker atom
 
-In terms of styling there are four major classnames for the Booker, i.e. `bookerContainer`, `eventMetaCustomClassNames`, `datePickerCustomClassNames` and `availableTimeSlotsCustomClassNames`. Most of the classnames fall into one of sub classes these four classnames have.
+Booker atom accepts custom styles via the **customClassNames** prop. All the props that we see below fall under this **customClassNames** prop. In terms of styling there are four major classnames for the Booker, i.e. **bookerContainer**, **eventMetaCustomClassNames**, **datePickerCustomClassNames** and **availableTimeSlotsCustomClassNames**. Most of the classnames below fall under one of these sub classes.
 
 {% classnamesTable atom="booker" /%}
 

--- a/pages/platform/atoms-reference/index.mdoc
+++ b/pages/platform/atoms-reference/index.mdoc
@@ -1,0 +1,40 @@
+---
+title: Atoms reference
+description: Everything related to atoms from props to styling.
+---
+
+## Props 
+
+Below is a list of tables that contains all the available props each atom contains.
+
+### 1. Google calendar connect atom
+
+{% table atom="google calendar" /%}
+
+### 2. Availability settings atom
+
+{% table atom="availability settings" /%}
+
+### 3. Booker atom
+
+{% table atom="booker" /%}
+
+## Styling
+
+Below is a list of tables that contains all the available classnames that can be used for each atom.
+
+### 1. Google calendar connect atom
+
+{% classnamesTable atom="google calendar" /%}
+
+### 2. Availability settings atom
+
+{% classnamesTable atom="availability settings" /%}
+
+### 3. Booker atom
+
+In terms of styling there are four major classnames for the Booker, i.e. `bookerContainer`, `eventMetaCustomClassNames`, `datePickerCustomClassNames` and `availableTimeSlotsCustomClassNames`. Most of the classnames fall into one of sub classes these four classnames have.
+
+{% classnamesTable atom="booker" /%}
+
+{% note type="info" %}Please note that sometimes the custom classnames may fail to override the styling with the classnames that you might have passed via props. That is because the **clsx** utility function that we use to override classnames inside our components has some limitations. A simple get around to solve this issue is to just prefix your classnames with **!** property just before passing in any classname.{% /note %}

--- a/pages/platform/booking-redirects/index.mdoc
+++ b/pages/platform/booking-redirects/index.mdoc
@@ -23,10 +23,9 @@ Page in the booking URL will take URL parameter provided by us and then hook to 
 3. When a booking occurs, booker will be re-directed to the redirectURI with booking UID as the bookingUid parameter aka my-app.com/bookings/[bookingUid].
 4. In the my-app.com/bookings/[bookingUid] route create a page that imports `useGetBooking` hook, then extract bookingUid from URL parameter, and uses the hook to display booking information:
 
-```
+```js
 import { useGetBooking } from "@calcom/atoms";
 
-...
 export default function Bookings(props: { calUsername: string; calEmail: string }) {
     const router = useRouter();
   
@@ -45,7 +44,7 @@ An example implementation can be found [here](https://github.com/calcom/cal.com/
 2. When “Reschedule” is clicked, user will be re-directed to the redirectURI with rescheduled and eventTypeSlug query parameters `my-app.com/reschedule?rescheduleUid=buiaE8jHmNAxLrqitahCeL&eventTypeSlug=thirty-minutes`
 3. In the my-app.com/reschedule route create a page that extracts `rescheduleUid` and `eventTypeSlug` from the query parameters and passes the to the `Booker` atom:
 
-```
+```js 
 const rescheduleUid = (router.query.rescheduleUid as string) ?? "";
 const eventTypeSlugQueryParam = (router.query.eventTypeSlug as string) ?? "";
 
@@ -67,7 +66,7 @@ An example implementation can be found [here](https://github.com/calcom/cal.com/
 3. In the page of my-app.com/cancel/[bookingUid] import useCancelBooking from atoms and get access to the cancel mutation
 import { useCancelBooking } from "@calcom/atoms";
 
-```
+```js
 const { mutate: cancelBooking } = useCancelBooking({
     onSuccess: () => {
       refetch();
@@ -77,7 +76,7 @@ const { mutate: cancelBooking } = useCancelBooking({
 
 4. Create a cancel button that invokes mutation returned by the “useCancelBooking” using the booking uid from the URL parameter. Provide a suitable “cancellationReason”.
 
-```
+```js 
 <button
     className="underline"
     onClick={() => {

--- a/pages/platform/faq/index.mdoc
+++ b/pages/platform/faq/index.mdoc
@@ -29,3 +29,6 @@ description: Answers to the most common questions about platform api and atoms.
 ### 6. What are the minimun setup requirments for using atoms?
 - You need to have a project that uses React version 18 and above.
 - At the moment atoms are only supported in React, so there's no way to use them in vanilla js or any other popular framework.
+
+### 7. Can recurring events be rescheduled?
+- No, at the moment you are only allowed to cancel a recurring event.

--- a/project-config.ts
+++ b/project-config.ts
@@ -516,6 +516,10 @@ export default {
           href: "/platform/booking-redirects"
         },
         {
+          title: "Atoms reference",
+          href: "/platform/atoms-reference"
+        },
+        {
           title: "FAQ",
           href: "/platform/faq"
         }

--- a/utils/atomsClassnameTableData.ts
+++ b/utils/atomsClassnameTableData.ts
@@ -1,0 +1,40 @@
+type AtomsClassnamesProp = {
+    name: string;
+    description: string
+}
+
+export const googleCalendarAtomClassnamesPropData: AtomsClassnamesProp[] = [
+    {name: 'className', description: 'Pass in custom classnames from outside for styling the button'},
+]
+
+export const availabilitySettingsAtomClassnamesPropData: AtomsClassnamesProp[] = [
+    {name: 'containerClassName', description: 'Adds styling to the whole availability settings component'},
+    {name: 'ctaClassName', description: 'Adds stylings only to certain call to action buttons'}, 
+    {name: 'editableHeadingClassName', description: 'Editable heading or title can be styled'}, 
+    {name: 'formClassName', description: 'Form which contains the days and toggles'},
+    {name: 'timezoneSelectClassName', description: 'Adds styling to the timezone select component'},
+    {name: 'subtitlesClassName', description: 'Styles the subtitle'}, 
+    {name: 'scheduleContainer', description: 'Styles the whole of the schedule component'}, 
+    {name: 'scheduleDay', description: 'Adds styling to just the day of a particular schedule'},
+    {name: 'dayRanges', description: 'Adds styling to day ranges'}, 
+    {name: 'timeRanges', description: 'Time ranges in the availability settings can be customized'}, 
+    {name: 'labelAndSwitchContainer', description: 'Adds styling to label and switches'}
+]
+
+export const bookerAtomPropsClassnamesPropData: AtomsClassnamesProp[] = [
+    {name: 'bookerContainer', description: 'Adds styling to the whole of booker atom'},
+    {name: 'eventMetaContainer', description: 'Styles the event meta component containing details about an event'}, 
+    {name: 'eventMetaTitle', description: 'Adds styles to the event meta title'}, 
+    {name: 'eventMetaTimezoneSelect', description: 'Adds styles to the event meta timezone selector'},
+    {name: 'datePickerContainer', description: 'Adds styling to the date picker'},
+    {name: 'datePickerTitle', description: 'Styles the date picker title'}, 
+    {name: 'datePickerDays', description: 'Adds styling to all days in the date picker'}, 
+    {name: 'datePickerDate', description: 'Adds styling to all date in the date picker'},
+    {name: 'datePickerDatesActive', description: 'Styles only the dates where a user has an available slot'},
+    {name: 'datePickerToggle', description: 'Styles the left and right toggle buttons'}, 
+    {name: 'availableTimeSlotsContainer', description: 'Adds styling to available time slots component'}, 
+    {name: 'availableTimeSlotsHeaderContainer', description: 'Styles only the header container'},
+    {name: 'availableTimeSlotsTitle', description: 'Adds styles to the title'}, 
+    {name: 'availableTimeSlotsTimeFormatToggle', description: 'Adds styles to the format toggle buttons'}, 
+    {name: 'availableTimes', description: 'Styles all the available times container'}
+]

--- a/utils/atomsPropTableData.ts
+++ b/utils/atomsPropTableData.ts
@@ -1,0 +1,56 @@
+type AtomsProp = {
+    name: string;
+    required: boolean;
+    description: string
+}
+
+export const googleCalendarAtomPropsData: AtomsProp[] = [
+    {name: 'className', required: false, description: 'To pass in custom classnames from outside for styling the atom'},
+    {name: 'label', required: false, description: 'The label for the connect button'}, 
+    {name: 'alreadyConnectedLabel', required: false, description: 'The label for the already connected button'}, 
+    {name: 'onCheckError', required: false, description: 'A callback function to handle errors when checking the connection status'}
+]
+
+export const availabilitySettingsAtomPropsData: AtomsProp[] = [
+    {name: 'id', required: false, description: `The id of the schedule which fetches a user's availability`},
+    {name: 'labels', required: false, description: 'Helpful if you wanna pass in your own lables for i18n'},
+    {name: 'customClassNames', required: false, description: 'To pass in custom classnames from outside for styling the atom'}, 
+    {name: 'onUpdateSuccess', required: false, description: 'A callback function to handle updating user availability successfully'},
+    {name: 'onUpdateError', required: false, description: 'A callback function that gets triggered when the user availability fails to update'}, 
+    {name: 'onDeleteSuccess', required: false, description: 'A callback function that gets triggered when the user availability is deleted successfully'},
+    {name: 'onDeleteError', required: false, description: 'A callback function that gets triggered when the user availability is not deleted successfully'}, 
+]
+
+export const bookerAtomPropsData: AtomsProp[] = [
+    {name: 'username', required: true, description: 'Username of the person whose schedule is to be displayed'}, 
+    {name: 'eventSlug', required: true, description: 'Unique slug created for a particular event'},
+    {name: 'orgBannerUrl', required: false, description: `URL of a users current organization`},
+    {name: 'customClassNames', required: false, description: 'To pass in custom classnames from outside for styling the atom'},
+    {name: 'month', required: false, description: 'The exact month that we wanna display a users availability for. If no value is passed it defaults to the current month'}, 
+    {name: 'selectedDate', required: false, description: 'Default selected date for which the slotpicker will always open'},
+    {name: 'hideBranding', required: false, description: 'For hiding any branding on the booker'}, 
+    {name: 'isAway', required: false, description: 'Sets the booker component to the away state'},
+    {name: 'allowsDynamicBooking', required: false, description: 'Boolean to indicate if the bookig is a dynamic booking'}, 
+    {name: 'bookingData', required: false, description: 'When rescheduling a booking, the current bookings data is passed in via this prop'}, 
+    {name: 'isTeamEvent', required: false, description: 'Boolean to indicate if it is a team event. If this boolean is passed, we will only check team events with this slug and event slug'},
+    {name: 'duration', required: false, description: 'Refers to a multiple-duration event-type. If not passed, we select the default value'}, 
+    {name: 'durationConfig', required: false, description: 'Configures the selectable options for a multi-duration event type'},
+    {name: 'hashedLink', required: false, description: 'Refers to the private link from event types page'}, 
+    {name: 'isInstantMeeting', required: false, description: `Boolean to indicate if the booking is an instant meeting or not`},
+    {name: 'rescheduleUid', required: true, description: 'A unique id that is generated at the time of rescheduling a booking'}, 
+    {name: 'bookingUid', required: true, description: 'A unique id that is generated at the time of creating a booking'},
+    {name: 'firstName', required: false, description: `First name of the attendee`},
+    {name: 'lastName', required: false, description: 'Last name of the attendee'},
+    {name: 'guests', required: false, description: 'Invite a guest to join a meeting'}, 
+    {name: 'name', required: false, description: 'Host name'},
+    {name: 'onCreateBookingSuccess', required: false, description: 'A callback function to handle successful creation of a booking'}, 
+    {name: 'onCreateBookingError', required: false, description: 'A callback function that gets triggered when the booking creation process fails'},
+    {name: 'onCreateRecurringBookingSuccess', required: false, description: 'A callback function to handle successful creation of a recurring booking'}, 
+    {name: 'onCreateRecurringBookingError', required: false, description: 'A callback function that gets triggered when the process of creating a recurring booking fails'}, 
+    {name: 'onCreateInstantBookingSuccess', required: false, description: 'A callback function to handle successful creation of an instant booking'},
+    {name: 'onCreateInstantBookingError', required: false, description: 'A callback function that gets triggered when the process of creating an instant booking fails'}, 
+    {name: 'onReserveSlotSuccess', required: false, description: 'A callback function to handle successful reservation of a slot'},
+    {name: 'onReserveSlotError', required: false, description: 'A callback function that gets triggered when the process of reserving a slot fails'}, 
+    {name: 'onDeleteSlotSuccess', required: false, description: 'A callback function to handle successful deletion of a slot'},
+    {name: 'onDeleteSlotError', required: false, description: 'A callback function that gets triggered when the process of deleting a slot fails'}, 
+]

--- a/utils/atomsPropTableData.ts
+++ b/utils/atomsPropTableData.ts
@@ -4,6 +4,12 @@ type AtomsProp = {
     description: string
 }
 
+export enum Atoms {
+    Gcal = "google calendar",
+    Availability = "availability settings",
+    Booker = "booker"
+}
+
 export const googleCalendarAtomPropsData: AtomsProp[] = [
     {name: 'className', required: false, description: 'To pass in custom classnames from outside for styling the atom'},
     {name: 'label', required: false, description: 'The label for the connect button'}, 


### PR DESCRIPTION
Adds an atoms reference page that contains info about all available props and custom classnames that can be applied for styling atoms.