### PR TITLE
chore: update platform docs

### DIFF
--- a/pages/platform/atoms-reference/index.mdoc
+++ b/pages/platform/atoms-reference/index.mdoc
@@ -7,6 +7,8 @@ description: Everything related to atoms from props to styling.
 
 Below is a list of tables that contains all the available props each atom contains.
 
+{% note type="info" %}Please ensure all custom classnames are valid [Tailwind CSS](https://tailwindcss.com/) classnames.{% /note %}
+
 ### 1. Google calendar connect atom
 
 {% atomTable atom="google calendar" /%}

--- a/pages/platform/quick-start/index.mdoc
+++ b/pages/platform/quick-start/index.mdoc
@@ -10,7 +10,7 @@ description: Find out how to use Cal "atoms" to integrate scheduling into your p
 
 The first step is to create an OAuth client, which will allow to connect your users to Cal, so that atoms can handle their scheduling.
 
-1. After logging in using provided credentials, open OAuth clients settings page [https://app.cal.com/settings/organizations/platform/oauth-clients](https://app.cal.com/settings/organizations/platform/oauth-clients)
+1. After logging in using provided credentials, open OAuth clients settings page [https://app.cal.com/settings/platform/oauth-clients/create](https://app.cal.com/settings/platform/oauth-clients/create)
 2. Add an OAuth client.
     1. Name: anything is fine, you can call it, for example, same as your company or your website.
     2. Redirect URIs: Used to validate internal requests origin and allow redirections on your platform when needed. You can example any URI of your company’s domain e.g. in our case cal.com.


### PR DESCRIPTION
## This PR does the following things:
- Updates the link for OAuth client creation form in quickstart page 
- Adds a note in atoms styling reference stating we only accept tailwind css classnames as customclassnames