### PR TITLE
refactor: cancelling platform booking

### DIFF
--- a/pages/platform/booking-redirects/index.mdoc
+++ b/pages/platform/booking-redirects/index.mdoc
@@ -74,14 +74,25 @@ const { mutate: cancelBooking } = useCancelBooking({
 });
 ```
 
-4. Create a cancel button that invokes mutation returned by the “useCancelBooking” using the booking uid from the URL parameter. Provide a suitable “cancellationReason”.
+4. Create a cancel button that invokes mutation returned by the “useCancelBooking”. You have to pass id of the booking which you can get by fetching booking using "useGetBooking" hook by uid from the query params. Provide a suitable “cancellationReason”.
 
 ```js 
+import { useGetBooking, useCancelBooking } from "@calcom/atoms";
+
+...
+const { isLoading, data: booking, refetch } = useGetBooking((router.query.bookingUid as string) ?? "");
+const { mutate: cancelBooking } = useCancelBooking({
+    onSuccess: () => {
+      refetch();
+    },
+  });
+...
+
 <button
     className="underline"
     onClick={() => {
         cancelBooking({
-            uid: booking.uid,
+            id: booking.id,
             cancellationReason: "User request",
         });
     }}>


### PR DESCRIPTION
We previously had example that required id and uid of booking to be passed to cancellation hook when in reality we only need booking id.

<img width="972" alt="Screenshot 2024-08-02 at 10 16 07" src="https://github.com/user-attachments/assets/163b947e-e33f-4622-8db8-a6d5645eaccc">
